### PR TITLE
Chore: 커밋 차단 범위 지정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "main" ]; then
+  echo "You can't commit directly to main branch"
+  exit 1
+fi
+
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm lint-staged


### PR DESCRIPTION
# pr 제목은 아래와 같이 작성해주세요.

- resolved #11

## 📝 작업 내용

### 📷 스크린샷

![image](https://github.com/GoGo-Ring/dongoorami-frontend/assets/88662637/0c43bdf9-c3ce-40cc-ad0a-d4ebdc4e8ab2)

커밋을 금지할 브랜치명을 현재 브랜치(chore/#11/block-main-commit)으로 지정한 모습입니다.
에러 문구는 문자열로 작성해서 여전히 main이지만, 커밋 차단 기능이 정상적으로 동작한다는 것을 확인할 수 있습니다.

참고:
- `#1`: 현재 브랜치명
- `#2`: 에러 문구

## 💬 리뷰 요구사항

