### PR TITLE
Feat: [#35] 구인 입력, Field 컴포넌트 추상화 와 useForm 훅 사용

### DIFF
--- a/app/recruitment/new/_components/common/field.tsx
+++ b/app/recruitment/new/_components/common/field.tsx
@@ -11,6 +11,7 @@ const FieldVariants = cva('', {
   variants: {
     variant: {
       title: 'flex w-full items-center',
+      slider: 'flex w-full items-center',
       default: 'flex w-[45%] items-center',
     },
   },
@@ -22,8 +23,9 @@ const FieldVariants = cva('', {
 const LabelVariants = cva('', {
   variants: {
     labelVariant: {
-      radio: 'pr-4 text-base ',
+      radio: 'pr-4 text-base',
       default: 'w-24 flex-shrink-0 text-nowrap text-base font-semibold',
+      slider: '',
     },
   },
   defaultVariants: {

--- a/app/recruitment/new/_components/common/field.tsx
+++ b/app/recruitment/new/_components/common/field.tsx
@@ -1,0 +1,56 @@
+import { Label } from '@radix-ui/react-label';
+import { VariantProps, cva } from 'class-variance-authority';
+import { PropsWithChildren } from 'react';
+
+import { cn } from '~/libs/utils';
+
+import { INITIAL_VALUES } from '../../constants';
+
+export type FieldIds = keyof typeof INITIAL_VALUES;
+
+const FieldVariants = cva('', {
+  variants: {
+    variant: {
+      title: 'flex w-full items-center',
+      default: 'flex w-[45%] items-center',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+const LabelVariants = cva('', {
+  variants: {
+    labelVariant: {
+      radio: 'pr-4 text-base ',
+      default: 'w-24 flex-shrink-0 text-nowrap text-base font-semibold',
+    },
+  },
+  defaultVariants: {
+    labelVariant: 'default',
+  },
+});
+
+export interface FieldProps
+  extends VariantProps<typeof FieldVariants>,
+    VariantProps<typeof LabelVariants> {
+  id: FieldIds;
+  label?: string;
+  placeholder?: string;
+}
+
+export const Field = ({
+  children,
+  id,
+  label,
+  variant,
+  labelVariant,
+}: PropsWithChildren<FieldProps>) => (
+  <div className={cn(FieldVariants({ variant }))}>
+    <Label className={cn(LabelVariants({ labelVariant }))} htmlFor={id}>
+      {label}
+    </Label>
+    {children}
+  </div>
+);

--- a/app/recruitment/new/_components/common/field.tsx
+++ b/app/recruitment/new/_components/common/field.tsx
@@ -1,7 +1,7 @@
-import { Label } from '@radix-ui/react-label';
 import { VariantProps, cva } from 'class-variance-authority';
 import { PropsWithChildren } from 'react';
 
+import { Label } from '~/components/label';
 import { cn } from '~/libs/utils';
 
 import { INITIAL_VALUES } from '../../constants';

--- a/app/recruitment/new/_components/common/field.tsx
+++ b/app/recruitment/new/_components/common/field.tsx
@@ -1,10 +1,9 @@
 import { VariantProps, cva } from 'class-variance-authority';
 import { PropsWithChildren } from 'react';
 
+import { INITIAL_VALUES } from '~/app/recruitment/new/constants';
 import { Label } from '~/components/label';
 import { cn } from '~/libs/utils';
-
-import { INITIAL_VALUES } from '../../constants';
 
 export type FieldIds = keyof typeof INITIAL_VALUES;
 

--- a/app/recruitment/new/_components/common/form.tsx
+++ b/app/recruitment/new/_components/common/form.tsx
@@ -1,0 +1,31 @@
+import { ReactNode, createContext } from 'react';
+
+import useForm from '~/hooks/useForm';
+
+import { INITIAL_VALUES } from '../../constants';
+
+export const FormContext = createContext<ReturnType<
+  typeof useForm<typeof INITIAL_VALUES>
+> | null>(null);
+
+FormContext.displayName = 'FormContext';
+
+interface FormProps {
+  children: ReactNode;
+}
+
+export const Form = ({ children }: FormProps) => {
+  const formValues = useForm(INITIAL_VALUES, values => values); // TODO: 제출 로직 추가
+  const { handleSubmit } = formValues;
+
+  return (
+    <FormContext.Provider value={formValues}>
+      <form
+        className="flex w-[890px] flex-col justify-center gap-12"
+        onSubmit={handleSubmit}
+      >
+        {children}
+      </form>
+    </FormContext.Provider>
+  );
+};

--- a/app/recruitment/new/_components/common/form.tsx
+++ b/app/recruitment/new/_components/common/form.tsx
@@ -4,9 +4,17 @@ import useForm from '~/hooks/useForm';
 
 import { INITIAL_VALUES } from '../../constants';
 
-export const FormContext = createContext<ReturnType<
-  typeof useForm<typeof INITIAL_VALUES>
-> | null>(null);
+const INITIAL_RETURN_FORM_VALUES = {
+  values: INITIAL_VALUES,
+  errors: {} as Record<keyof typeof INITIAL_VALUES, boolean>,
+  setValues: () => {},
+  handleChange: () => {},
+  handleSubmit: () => {},
+};
+
+export const FormContext = createContext<
+  ReturnType<typeof useForm<typeof INITIAL_VALUES>>
+>(INITIAL_RETURN_FORM_VALUES);
 
 FormContext.displayName = 'FormContext';
 

--- a/app/recruitment/new/_components/common/form.tsx
+++ b/app/recruitment/new/_components/common/form.tsx
@@ -2,15 +2,7 @@ import { ReactNode, createContext } from 'react';
 
 import useForm from '~/hooks/useForm';
 
-import { INITIAL_VALUES } from '../../constants';
-
-const INITIAL_RETURN_FORM_VALUES = {
-  values: INITIAL_VALUES,
-  errors: {} as Record<keyof typeof INITIAL_VALUES, boolean>,
-  setValues: () => {},
-  handleChange: () => {},
-  handleSubmit: () => {},
-};
+import { INITIAL_RETURN_FORM_VALUES, INITIAL_VALUES } from '../../constants';
 
 export const FormContext = createContext<
   ReturnType<typeof useForm<typeof INITIAL_VALUES>>

--- a/app/recruitment/new/_components/common/form.tsx
+++ b/app/recruitment/new/_components/common/form.tsx
@@ -1,8 +1,10 @@
 import { ReactNode, createContext } from 'react';
 
+import {
+  INITIAL_RETURN_FORM_VALUES,
+  INITIAL_VALUES,
+} from '~/app/recruitment/new/constants';
 import useForm from '~/hooks/useForm';
-
-import { INITIAL_RETURN_FORM_VALUES, INITIAL_VALUES } from '../../constants';
 
 export const FormContext = createContext<
   ReturnType<typeof useForm<typeof INITIAL_VALUES>>

--- a/app/recruitment/new/_components/double-thumb-slider.tsx
+++ b/app/recruitment/new/_components/double-thumb-slider.tsx
@@ -20,8 +20,8 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-5 w-5 cursor-pointer rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block h-5 w-5 cursor-pointer rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ));
 

--- a/app/recruitment/new/_components/form-field.tsx
+++ b/app/recruitment/new/_components/form-field.tsx
@@ -135,7 +135,21 @@ export const SliderField = ({
   label,
   variant,
 }: SliderFieldProps) => {
-  const { setValues, handleChange, values } = useContext(FormContext);
+  const { setValues, values } = useContext(FormContext);
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.currentTarget;
+
+    if (Number(value) < 0 || Number(value) > 100) {
+      return;
+    } else if (id === maxId && Number(value) < Number(values[minId])) {
+      return;
+    } else if (id === minId && Number(value) > Number(values[maxId])) {
+      return;
+    } else {
+      setValues({ ...values, [id]: value });
+    }
+  };
 
   return (
     <Field id={id} label={label} variant={variant}>
@@ -143,24 +157,25 @@ export const SliderField = ({
         <div className="flex items-center gap-4">
           <Input
             id={minId}
-            type="text"
+            type="number"
             min={0}
+            max={100}
             value={values[minId]}
-            onChange={handleChange}
+            onChange={handleSliderChange}
           />
           ~
           <Input
             id={maxId}
-            type="text"
+            type="number"
+            min={0}
             max={100}
             value={values[maxId]}
-            onChange={handleChange}
+            onChange={handleSliderChange}
           />
         </div>
         <Slider
           id={id}
           value={[Number(values[minId]), Number(values[maxId])]}
-          minStepsBetweenThumbs={1}
           onValueChange={value => {
             setValues({ ...values, [minId]: value[0], [maxId]: value[1] });
           }}

--- a/app/recruitment/new/_components/form-field.tsx
+++ b/app/recruitment/new/_components/form-field.tsx
@@ -1,0 +1,196 @@
+'use client';
+import { PropsWithChildren, useContext } from 'react';
+
+import { Input } from '~/components/input';
+import { RadioGroup, RadioGroupItem } from '~/components/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/select';
+
+import { Field, FieldProps, FieldIds } from './common/field';
+import { FormContext } from './common/form';
+import { Slider } from './double-thumb-slider';
+
+interface SelectFieldItemProps {
+  items: string[];
+}
+
+interface SliderFieldProps extends FieldProps {
+  minId: FieldIds;
+  maxId: FieldIds;
+}
+
+export const InputField = ({ id, placeholder, label, variant }: FieldProps) => {
+  const fieldProps = useContext(FormContext);
+
+  if (!fieldProps) {
+    return null;
+  }
+  const { values, handleChange } = fieldProps;
+
+  return (
+    <Field id={id} label={label} variant={variant}>
+      <Input
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        value={values[id]}
+        onChange={handleChange}
+      />
+    </Field>
+  );
+};
+
+export const FileField = ({ id, placeholder, label, variant }: FieldProps) => {
+  const fieldProps = useContext(FormContext);
+
+  if (!fieldProps) {
+    return null;
+  }
+  const { values, handleChange } = fieldProps;
+
+  return (
+    <Field id={id} label={label} variant={variant}>
+      <Input
+        id={id}
+        className="cursor-pointer"
+        type="file"
+        placeholder={placeholder}
+        value={values[id]}
+        onChange={handleChange}
+      />
+    </Field>
+  );
+};
+
+export const SelectField = ({
+  id,
+  placeholder,
+  label,
+  variant,
+  children,
+}: PropsWithChildren<FieldProps>) => {
+  const fieldProps = useContext(FormContext);
+
+  if (!fieldProps) {
+    return null;
+  }
+  const { setValues, values } = fieldProps;
+
+  return (
+    <Field id={id} label={label} variant={variant}>
+      <Select
+        onValueChange={value => {
+          setValues({ ...values, [id]: value });
+        }}
+        value={values[id]}
+      >
+        <SelectTrigger className="w-[180px]" id={id}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>{children}</SelectGroup>
+        </SelectContent>
+      </Select>
+    </Field>
+  );
+};
+
+export const SelectFieldItem = ({ items }: SelectFieldItemProps) => (
+  <>
+    {items?.map(location => (
+      <SelectItem key={location} value={location}>
+        {location}
+      </SelectItem>
+    ))}
+  </>
+);
+
+export const RadioGroupField = ({
+  id,
+  label,
+  children,
+  variant,
+}: PropsWithChildren<FieldProps>) => {
+  const fieldProps = useContext(FormContext);
+
+  if (!fieldProps) {
+    return null;
+  }
+  const { setValues, values } = fieldProps;
+
+  return (
+    <Field id={id} label={label} variant={variant}>
+      <RadioGroup
+        id={id}
+        className="flex w-full items-center"
+        onValueChange={value => {
+          setValues({ ...values, [id]: value });
+        }}
+        value={values[id]}
+      >
+        {children}
+      </RadioGroup>
+    </Field>
+  );
+};
+
+export const RadioGroupFieldItem = ({ id, label }: FieldProps) => {
+  return (
+    <Field id={id} label={label} labelVariant="radio">
+      <RadioGroupItem value={id} id={id} />
+    </Field>
+  );
+};
+
+export const SliderField = ({
+  id,
+  minId,
+  maxId,
+  label,
+  variant,
+}: SliderFieldProps) => {
+  const fieldProps = useContext(FormContext);
+
+  if (!fieldProps) {
+    return null;
+  }
+  const { setValues, handleChange, values } = fieldProps;
+
+  return (
+    <Field id={id} label={label} variant={variant}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-4">
+          <Input
+            id={minId}
+            type="text"
+            min={0}
+            value={values[minId]}
+            onChange={handleChange}
+          />
+          ~
+          <Input
+            id={maxId}
+            type="text"
+            max={100}
+            value={values[maxId]}
+            onChange={handleChange}
+          />
+        </div>
+        <Slider
+          id={id}
+          value={[Number(values[minId]), Number(values[maxId])]}
+          minStepsBetweenThumbs={1}
+          onValueChange={value => {
+            setValues({ ...values, [minId]: value[0], [maxId]: value[1] });
+          }}
+        />
+      </div>
+    </Field>
+  );
+};

--- a/app/recruitment/new/_components/form-field.tsx
+++ b/app/recruitment/new/_components/form-field.tsx
@@ -26,12 +26,7 @@ interface SliderFieldProps extends FieldProps {
 }
 
 export const InputField = ({ id, placeholder, label, variant }: FieldProps) => {
-  const fieldProps = useContext(FormContext);
-
-  if (!fieldProps) {
-    return null;
-  }
-  const { values, handleChange } = fieldProps;
+  const { values, handleChange } = useContext(FormContext);
 
   return (
     <Field id={id} label={label} variant={variant}>
@@ -47,12 +42,7 @@ export const InputField = ({ id, placeholder, label, variant }: FieldProps) => {
 };
 
 export const FileField = ({ id, placeholder, label, variant }: FieldProps) => {
-  const fieldProps = useContext(FormContext);
-
-  if (!fieldProps) {
-    return null;
-  }
-  const { values, handleChange } = fieldProps;
+  const { values, handleChange } = useContext(FormContext);
 
   return (
     <Field id={id} label={label} variant={variant}>
@@ -75,12 +65,7 @@ export const SelectField = ({
   variant,
   children,
 }: PropsWithChildren<FieldProps>) => {
-  const fieldProps = useContext(FormContext);
-
-  if (!fieldProps) {
-    return null;
-  }
-  const { setValues, values } = fieldProps;
+  const { setValues, values } = useContext(FormContext);
 
   return (
     <Field id={id} label={label} variant={variant}>
@@ -117,12 +102,7 @@ export const RadioGroupField = ({
   children,
   variant,
 }: PropsWithChildren<FieldProps>) => {
-  const fieldProps = useContext(FormContext);
-
-  if (!fieldProps) {
-    return null;
-  }
-  const { setValues, values } = fieldProps;
+  const { setValues, values } = useContext(FormContext);
 
   return (
     <Field id={id} label={label} variant={variant}>
@@ -155,12 +135,7 @@ export const SliderField = ({
   label,
   variant,
 }: SliderFieldProps) => {
-  const fieldProps = useContext(FormContext);
-
-  if (!fieldProps) {
-    return null;
-  }
-  const { setValues, handleChange, values } = fieldProps;
+  const { setValues, handleChange, values } = useContext(FormContext);
 
   return (
     <Field id={id} label={label} variant={variant}>

--- a/app/recruitment/new/constants.ts
+++ b/app/recruitment/new/constants.ts
@@ -1,42 +1,5 @@
-export const FORM_IDS = {
-  TITLE: 'title',
-  PERFORMANCE_NAME: 'performanceName',
-  PERFORMANCE_DATE: 'performanceDate',
-  PERFORMANCE_LOCATION: 'performanceLocation',
-  REGION: 'region',
-  AGE: 'age',
-  PARTICIPANT_COUNT: 'participantCount',
-  MALE: 'male',
-  FEMALE: 'female',
-  IRRELEVANT: 'irrelevant',
-  GENDER: 'gender',
-};
-
-export const FORM_LABELS = {
-  TITLE: '제목',
-  PERFORMANCE_NAME: '공연명',
-  PERFORMANCE_DATE: '공연일',
-  PERFORMANCE_LOCATION: '공연 장소',
-  REGION: '지역',
-  AGE: '연령',
-  PARTICIPANT_COUNT: '인원수',
-  MALE: '남',
-  FEMALE: '여',
-  IRRELEVANT: '무관',
-  GENDER: '성별',
-};
-
-export const FORM_PLACEHOLDERS = {
-  TITLE: '제목을 입력해주세요',
-  PERFORMANCE_NAME: '공연명을 입력해주세요',
-  PERFORMANCE_LOCATION: '공연 장소를 입력해주세요',
-  REGION: '선택',
-  PARTICIPANT_COUNT: '선택',
-  TEXTAREA: '내용을 입력해주세요',
-};
-
 export const FORM_ITEMS = {
-  LOCATION: [
+  REGIONS: [
     '서울',
     '경기',
     '인천',
@@ -54,5 +17,38 @@ export const FORM_ITEMS = {
     '전남',
     '제주',
   ],
-  PARTICIPANTS: Array.from({ length: 100 }, (_, i) => `${i + 1}명`),
+  PARTICIPANT_COUNT: Array.from({ length: 100 }, (_, i) => `${i + 1}명`),
+  GENDER: [
+    {
+      label: '남',
+      id: 'male',
+    },
+    {
+      label: '여',
+      id: 'female',
+    },
+    {
+      label: '무관',
+      id: 'irrelevant',
+    },
+  ] as const,
+};
+
+export const INITIAL_VALUES = {
+  title: '',
+  performanceName: '',
+  performanceDate: '',
+  performanceLocation: '',
+  participantCount: '',
+  region: '',
+  age: '20~30',
+  minAge: '20',
+  maxAge: '30',
+  gender: '',
+  male: '',
+  female: '',
+  irrelevant: '',
+  image: '',
+  count: '',
+  textArea: '',
 };

--- a/app/recruitment/new/constants.ts
+++ b/app/recruitment/new/constants.ts
@@ -52,3 +52,11 @@ export const INITIAL_VALUES = {
   count: '',
   textArea: '',
 };
+
+export const INITIAL_RETURN_FORM_VALUES = {
+  values: INITIAL_VALUES,
+  errors: {} as Record<keyof typeof INITIAL_VALUES, boolean>,
+  setValues: () => {},
+  handleChange: () => {},
+  handleSubmit: () => {},
+};

--- a/app/recruitment/new/page.tsx
+++ b/app/recruitment/new/page.tsx
@@ -1,158 +1,63 @@
 'use client';
+import React from 'react';
+
 import { Button } from '~/components/button';
-import { Input } from '~/components/input';
-import { Label } from '~/components/label';
-import { RadioGroup, RadioGroupItem } from '~/components/radio-group';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '~/components/select';
 import { Textarea } from '~/components/textarea';
 
-import { Slider } from './_components/double-thumb-slider';
+import { Form } from './_components/common/form';
 import {
-  FORM_IDS,
-  FORM_ITEMS,
-  FORM_LABELS,
-  FORM_PLACEHOLDERS,
-} from './constants';
-
-interface FieldProps {
-  children: React.ReactNode;
-  htmlFor?: string;
-  label?: string;
-}
-
-const Field = ({ children, htmlFor, label }: FieldProps) => (
-  <div className="flex w-[45%] items-center ">
-    <Label
-      className=" w-24 flex-shrink-0 text-nowrap text-base font-semibold"
-      htmlFor={htmlFor}
-    >
-      {label}
-    </Label>
-    {children}
-  </div>
-);
+  FileField,
+  InputField,
+  RadioGroupField,
+  RadioGroupFieldItem,
+  SelectField,
+  SelectFieldItem,
+  SliderField,
+} from './_components/form-field';
+import { FORM_ITEMS } from './constants';
 
 const Page = () => {
   return (
     <div className="flex justify-center py-10">
-      <form className="flex w-[890px] flex-col justify-center gap-12">
+      <Form>
         <div className="flex w-full items-center gap-7">
-          <Label
-            className="text-nowrap text-xl font-semibold"
-            htmlFor={FORM_IDS.TITLE}
-          >
-            제목
-          </Label>
-          <Input
-            id={FORM_IDS.TITLE}
-            type="text"
-            placeholder={FORM_PLACEHOLDERS.TITLE}
+          <InputField
+            id="title"
+            label="제목"
+            placeholder="제목을 입력해주세요"
+            variant="title"
           />
         </div>
-
-        <Field htmlFor="image" label="이미지">
-          <Input type="file" id="image" />
-        </Field>
-
+        <FileField id="image" label="이미지" />
         <div className="flex flex-wrap items-center gap-7 rounded-md border border-gray-200 p-6">
-          <Field
-            htmlFor={FORM_IDS.PERFORMANCE_NAME}
-            label={FORM_LABELS.PERFORMANCE_NAME}
-          >
-            <Input
-              id={FORM_IDS.PERFORMANCE_NAME}
-              type="text"
-              placeholder={FORM_PLACEHOLDERS.PERFORMANCE_NAME}
-            />
-          </Field>
-
-          <Field
-            htmlFor={FORM_IDS.PERFORMANCE_LOCATION}
-            label={FORM_LABELS.PERFORMANCE_LOCATION}
-          >
-            <Input
-              id={FORM_IDS.PERFORMANCE_LOCATION}
-              type="text"
-              placeholder={FORM_PLACEHOLDERS.PERFORMANCE_LOCATION}
-            />
-          </Field>
-
-          <Field htmlFor={FORM_IDS.REGION} label={FORM_LABELS.REGION}>
-            <Select>
-              <SelectTrigger className="w-[180px]" id={FORM_IDS.REGION}>
-                <SelectValue placeholder={FORM_PLACEHOLDERS.REGION} />
-              </SelectTrigger>
-              <SelectContent>
-                {FORM_ITEMS.LOCATION.map(location => (
-                  <SelectItem key={location} value={location}>
-                    {location}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
-
-          <div className=" flex w-[45%] items-center">
-            <legend className="w-24 flex-shrink-0 text-nowrap text-base font-semibold">
-              {FORM_LABELS.AGE}
-            </legend>
-            <div className="flex flex-col gap-4">
-              <div className="flex gap-4">
-                <Input type="text" min={0} />
-                <Input type="text" max={100} />
-              </div>
-              <Slider defaultValue={[20, 30]} minStepsBetweenThumbs={1} />
-            </div>
-          </div>
-
-          <Field
-            htmlFor={FORM_IDS.PARTICIPANT_COUNT}
-            label={FORM_LABELS.PARTICIPANT_COUNT}
-          >
-            <Select>
-              <SelectTrigger
-                className="w-[180px]"
-                id={FORM_IDS.PARTICIPANT_COUNT}
-              >
-                <SelectValue
-                  placeholder={FORM_PLACEHOLDERS.PARTICIPANT_COUNT}
-                />
-              </SelectTrigger>
-              <SelectContent id={FORM_IDS.PARTICIPANT_COUNT}>
-                {FORM_ITEMS.PARTICIPANTS.map(participant => (
-                  <SelectItem key={participant} value={participant}>
-                    {participant}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
-
-          <Field label={FORM_LABELS.GENDER}>
-            <RadioGroup className="flex w-full">
-              <RadioGroupItem value="male" id={FORM_IDS.MALE} />
-              <Label htmlFor={FORM_IDS.MALE}>{FORM_LABELS.MALE}</Label>
-              <RadioGroupItem value="female" id={FORM_IDS.FEMALE} />
-              <Label htmlFor={FORM_IDS.FEMALE}>{FORM_LABELS.FEMALE}</Label>
-              <RadioGroupItem value="any" id={FORM_IDS.IRRELEVANT} />
-              <Label htmlFor={FORM_IDS.IRRELEVANT}>
-                {FORM_LABELS.IRRELEVANT}
-              </Label>
-            </RadioGroup>
-          </Field>
+          <InputField
+            id="performanceName"
+            label="공연명"
+            placeholder="공연명을 입력해주세요"
+          />
+          <InputField
+            id="performanceLocation"
+            label="공연 장소"
+            placeholder="공연 장소를 입력해주세요"
+          />
+          <SelectField id="region" label="지역" placeholder="선택">
+            <SelectFieldItem items={FORM_ITEMS.REGIONS} />
+          </SelectField>
+          <SelectField id="participantCount" label="인원수" placeholder="선택">
+            <SelectFieldItem items={FORM_ITEMS.PARTICIPANT_COUNT} />
+          </SelectField>
+          <SliderField id="age" minId="minAge" maxId="maxAge" label="연령" />
+          <RadioGroupField id="gender" label="성별">
+            {FORM_ITEMS.GENDER.map(({ label, id }) => (
+              <RadioGroupFieldItem key={id} id={id} label={label} />
+            ))}
+          </RadioGroupField>
         </div>
-
         <Textarea
-          className="h-80 resize-none"
-          placeholder={FORM_PLACEHOLDERS.TEXTAREA}
+          className="h-96 resize-none"
+          id="textarea"
+          placeholder="내용을 입력해주세요"
         />
-
         <div className="flex gap-8">
           <Button className="w-full bg-secondary text-secondary-foreground">
             취소
@@ -161,7 +66,7 @@ const Page = () => {
             입력 완료
           </Button>
         </div>
-      </form>
+      </Form>
     </div>
   );
 };

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+type HandleChange = <
+  E extends HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+>(
+  e: React.ChangeEvent<E>,
+) => void;
+
+type HandleSubmit = (e: React.FormEvent<HTMLFormElement>) => void;
+
+type UseForm = <T extends Record<string, string>>(
+  initialValues: T,
+  onSubmit: (values: T) => void,
+) => {
+  values: T;
+  errors: Record<keyof T, boolean>;
+  setValues: React.Dispatch<React.SetStateAction<T>>;
+  handleChange: HandleChange;
+  handleSubmit: HandleSubmit;
+};
+
+const useForm: UseForm = <T>(
+  initialValues: T,
+  onSubmit: (values: T) => void,
+) => {
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<Record<keyof T, boolean>>(
+    {} as Record<keyof T, boolean>,
+  );
+
+  const handleChange: HandleChange = e => {
+    const { id, value } = e.currentTarget;
+
+    if (!value) {
+      setErrors({ ...errors, [id]: true });
+
+      return;
+    }
+    setValues({ ...values, [id]: value });
+    setErrors({ ...errors, [id]: false });
+  };
+
+  const handleSubmit: HandleSubmit = e => {
+    e.preventDefault();
+    onSubmit(values);
+  };
+
+  return {
+    values,
+    errors,
+    setValues,
+    handleChange,
+    handleSubmit,
+  };
+};
+
+export default useForm;


### PR DESCRIPTION
## 📝 작업 내용
- 타입 스크립트 자동완성으로 constant 데이터를 일부 제거하였습니다.
- 구인 입력 페이지의 Field 컴포넌트 추상화를 진행하였습니다.
- useForm 훅을 사용하였습니다.

### 작업 이유
page 컴포넌트에 너무많은 정보가 있어 가독성이 떨어졌고, 
form state 관리 또한 숨기는게 가독성에 좋을것 같다는 판단을 하여 진행하였습니다.

재준님께서 의견 주신 가독성 문제에대해
constant 대신, 타입 자동완성으로 대체할수있다 판단하여 진행했습니다.

- close #35 
## 💬 리뷰 요구사항(선택)
- [ ] constants.ts 에 INITIAL_VALUES 를 `keyof typeof INITIAL_VALUES` 로 타입을 만들었습니다. INITIAL_VALUES 한곳만 정의하면, 다른 곳 에서 자동완성이 제공됩니다. 여기서 INITIAL_VALUES 는 컴포넌트의 id 를 키로 하고 매핑되는 값에 state 를 관리하는 식입니다. 두개의 기능이 있다보니, 실제로 state 를 사용하지않고, id 만 필요한 곳에도, 자동완성기능을 위해 INITIAL_VALUES 에 키값으로 등록하게되었습니다. 그렇다면, INITIAL_VALUES 외에 자동완성을 위한 key들에대한 유니온 타입을 따로 만드는게 좋을까요?? 
- [ ] form-field.tsx 컴포넌트들이 잘 추상화 되어있는지 궁금합니다.!