### PR TITLE
Feat: [#99] 공연 정보 페이지 UI 추가

### DIFF
--- a/app/performance/_components/info-item-with-button.tsx
+++ b/app/performance/_components/info-item-with-button.tsx
@@ -1,34 +1,42 @@
 'use client';
 
-import { Children, ReactNode, useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import InfoItem, { InfoItemProps } from './info-item';
+import Toggle from './toggle';
 
 interface InfoItemWithButtonProps extends InfoItemProps {
-  children: ReactNode;
+  children?: ReactNode;
+  defaultText?: string;
+  toggledText?: string;
 }
 
-const InfoItemWithButton = ({
+const InfoItemWithToggle = ({
   children,
+  defaultText,
+  toggledText,
   ...props
 }: InfoItemWithButtonProps) => {
   const [more, setMore] = useState(false);
 
-  const childrenArray = Children.toArray(children);
-  const [button, toggle] = childrenArray;
+  const handleClick = () => {
+    setMore(!more);
+  };
 
   return (
     <div className="relative">
-      <button
-        onClick={() => setMore(!more)}
+      <Toggle
+        isToggled={more}
+        onClick={handleClick}
         className="absolute right-0 top-1 text-gray-300 md:hidden lg:hidden"
+        defaultText={defaultText}
+        toggledText={toggledText}
       >
-        {toggle && (more ? toggle : button)}
-        {!toggle && button}
-      </button>
+        {children}
+      </Toggle>
       <InfoItem more={more} {...props} />
     </div>
   );
 };
 
-export default InfoItemWithButton;
+export default InfoItemWithToggle;

--- a/app/performance/_components/info-item-with-button.tsx
+++ b/app/performance/_components/info-item-with-button.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Children, ReactNode, useState } from 'react';
+
+import InfoItem, { InfoItemProps } from './info-item';
+
+interface InfoItemWithButtonProps extends InfoItemProps {
+  children: ReactNode;
+}
+
+export const InfoItemWithButton = ({
+  children,
+  ...props
+}: InfoItemWithButtonProps) => {
+  const [more, setMore] = useState(false);
+
+  const childrenArray = Children.toArray(children);
+  const [button, toggle] = childrenArray;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setMore(!more)}
+        className="absolute right-0 top-1 text-gray-300 md:hidden lg:hidden"
+      >
+        {toggle && (more ? toggle : button)}
+        {!toggle && button}
+      </button>
+      <InfoItem more={more} {...props} />
+    </div>
+  );
+};

--- a/app/performance/_components/info-item-with-button.tsx
+++ b/app/performance/_components/info-item-with-button.tsx
@@ -8,7 +8,7 @@ interface InfoItemWithButtonProps extends InfoItemProps {
   children: ReactNode;
 }
 
-export const InfoItemWithButton = ({
+const InfoItemWithButton = ({
   children,
   ...props
 }: InfoItemWithButtonProps) => {
@@ -30,3 +30,5 @@ export const InfoItemWithButton = ({
     </div>
   );
 };
+
+export default InfoItemWithButton;

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -60,7 +60,7 @@ const InfoItem = ({
   size,
   more = false,
 }: InfoItemProps) => {
-  const isArray = typeof contents !== 'string';
+  const isArray = Array.isArray(contents);
 
   return (
     <div className={cn('flex', className)}>

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -4,16 +4,12 @@ import { cn } from '~/libs/utils';
 
 const labelVariants = cva('', {
   variants: {
-    width: {
-      default: '',
-      90: 'w-[90px]',
-    },
     weight: {
       default: '',
       semibold: 'text-xl font-semibold',
     },
   },
-  defaultVariants: { width: 'default', weight: 'default' },
+  defaultVariants: { weight: 'default' },
 });
 
 const contentVariants = cva('', {
@@ -22,16 +18,12 @@ const contentVariants = cva('', {
       default: '',
       col: 'flex-col',
     },
-    gap: {
-      default: '',
-      1: 'gap-1',
-    },
     size: {
       default: '',
       sm: 'sm:flex-col',
     },
   },
-  defaultVariants: { direction: 'default', gap: 'default', size: 'default' },
+  defaultVariants: { direction: 'default', size: 'default' },
 });
 
 export interface InfoItemProps
@@ -44,16 +36,18 @@ export interface InfoItemProps
   contentClassName?: string;
   children?: React.ReactNode;
   more?: boolean;
+  labelWidth?: string;
+  contentGap?: string;
 }
 
 const InfoItem = ({
   className,
   label,
   contents,
-  width,
+  labelWidth = '',
   weight,
   direction,
-  gap,
+  contentGap = '',
   size,
   more = false,
 }: InfoItemProps) => {
@@ -61,11 +55,19 @@ const InfoItem = ({
 
   return (
     <div className={cn('flex', className)}>
-      <span className={cn('font-semibold', labelVariants({ width, weight }))}>
+      <span
+        className={cn('font-semibold', labelWidth, labelVariants({ weight }))}
+      >
         {label}
       </span>
       {isArray ? (
-        <ul className={cn('flex', contentVariants({ direction, gap, size }))}>
+        <ul
+          className={cn(
+            'flex',
+            contentGap,
+            contentVariants({ direction, size }),
+          )}
+        >
           {contents.map((text, index) => (
             <li className={'list-none'} key={`${text}_${index}`}>
               {text}

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -1,7 +1,4 @@
-'use client';
-
 import { VariantProps, cva } from 'class-variance-authority';
-import { Children, ReactNode, useState } from 'react';
 
 import { cn } from '~/libs/utils';
 
@@ -37,7 +34,7 @@ const contentVariants = cva('', {
   defaultVariants: { direction: 'default', gap: 'default', size: 'default' },
 });
 
-interface InfoItemProps
+export interface InfoItemProps
   extends VariantProps<typeof labelVariants>,
     VariantProps<typeof contentVariants> {
   className?: string;
@@ -78,31 +75,6 @@ const InfoItem = ({
       ) : (
         <span className={cn({ 'sm:line-clamp-3': !more })}>{contents}</span>
       )}
-    </div>
-  );
-};
-
-interface InfoItemWithButtonProps extends InfoItemProps {
-  children: ReactNode;
-}
-
-export const InfoItemWithButton = ({
-  children,
-  ...props
-}: InfoItemWithButtonProps) => {
-  const [more, setMore] = useState(false);
-
-  const [unfold, fold] = Children.toArray(children);
-
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setMore(!more)}
-        className="absolute right-0 top-1 text-gray-300 md:hidden lg:hidden"
-      >
-        {more ? fold : unfold}
-      </button>
-      <InfoItem more={more} {...props} />
     </div>
   );
 };

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { VariantProps, cva } from 'class-variance-authority';
+import { Children, ReactNode, useState } from 'react';
 
 import { cn } from '~/libs/utils';
 
@@ -43,6 +46,7 @@ interface InfoItemProps
   labelClassName?: string;
   contentClassName?: string;
   children?: React.ReactNode;
+  more?: boolean;
 }
 
 const InfoItem = ({
@@ -53,28 +57,52 @@ const InfoItem = ({
   weight,
   direction,
   gap,
-  children,
   size,
+  more = false,
 }: InfoItemProps) => {
   const isArray = typeof contents !== 'string';
 
   return (
     <div className={cn('flex', className)}>
-      <div className="flex justify-between">
-        <span className={cn('font-semibold', labelVariants({ width, weight }))}>
-          {label}
-        </span>
-        {children}
-      </div>
+      <span className={cn('font-semibold', labelVariants({ width, weight }))}>
+        {label}
+      </span>
       <div className={cn('flex', contentVariants({ direction, gap, size }))}>
         {isArray ? (
           contents.map((text, index) => (
-            <span key={`${text}_${index}`}>{text}</span>
+            <li className={'list-none'} key={`${text}_${index}`}>
+              {text}
+            </li>
           ))
         ) : (
-          <span>{contents}</span>
+          <span className={cn({ 'sm:line-clamp-3': !more })}>{contents}</span>
         )}
       </div>
+    </div>
+  );
+};
+
+interface InfoItemWithButtonProps extends InfoItemProps {
+  children: ReactNode;
+}
+
+export const InfoItemWithButton = ({
+  children,
+  ...props
+}: InfoItemWithButtonProps) => {
+  const [more, setMore] = useState(false);
+
+  const [unfold, fold] = Children.toArray(children);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setMore(!more)}
+        className="absolute right-0 top-1 text-gray-300 md:hidden lg:hidden"
+      >
+        {more ? fold : unfold}
+      </button>
+      <InfoItem more={more} {...props} />
     </div>
   );
 };

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -67,17 +67,17 @@ const InfoItem = ({
       <span className={cn('font-semibold', labelVariants({ width, weight }))}>
         {label}
       </span>
-      <div className={cn('flex', contentVariants({ direction, gap, size }))}>
-        {isArray ? (
-          contents.map((text, index) => (
+      {isArray ? (
+        <ul className={cn('flex', contentVariants({ direction, gap, size }))}>
+          {contents.map((text, index) => (
             <li className={'list-none'} key={`${text}_${index}`}>
               {text}
             </li>
-          ))
-        ) : (
-          <span className={cn({ 'sm:line-clamp-3': !more })}>{contents}</span>
-        )}
-      </div>
+          ))}
+        </ul>
+      ) : (
+        <span className={cn({ 'sm:line-clamp-3': !more })}>{contents}</span>
+      )}
     </div>
   );
 };

--- a/app/performance/_components/info-item.tsx
+++ b/app/performance/_components/info-item.tsx
@@ -1,0 +1,82 @@
+import { VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '~/libs/utils';
+
+const labelVariants = cva('', {
+  variants: {
+    width: {
+      default: '',
+      90: 'w-[90px]',
+    },
+    weight: {
+      default: '',
+      semibold: 'text-xl font-semibold',
+    },
+  },
+  defaultVariants: { width: 'default', weight: 'default' },
+});
+
+const contentVariants = cva('', {
+  variants: {
+    direction: {
+      default: '',
+      col: 'flex-col',
+    },
+    gap: {
+      default: '',
+      1: 'gap-1',
+    },
+    size: {
+      default: '',
+      sm: 'sm:flex-col',
+    },
+  },
+  defaultVariants: { direction: 'default', gap: 'default', size: 'default' },
+});
+
+interface InfoItemProps
+  extends VariantProps<typeof labelVariants>,
+    VariantProps<typeof contentVariants> {
+  className?: string;
+  label: string;
+  contents: string[] | string;
+  labelClassName?: string;
+  contentClassName?: string;
+  children?: React.ReactNode;
+}
+
+const InfoItem = ({
+  className,
+  label,
+  contents,
+  width,
+  weight,
+  direction,
+  gap,
+  children,
+  size,
+}: InfoItemProps) => {
+  const isArray = typeof contents !== 'string';
+
+  return (
+    <div className={cn('flex', className)}>
+      <div className="flex justify-between">
+        <span className={cn('font-semibold', labelVariants({ width, weight }))}>
+          {label}
+        </span>
+        {children}
+      </div>
+      <div className={cn('flex', contentVariants({ direction, gap, size }))}>
+        {isArray ? (
+          contents.map((text, index) => (
+            <span key={`${text}_${index}`}>{text}</span>
+          ))
+        ) : (
+          <span>{contents}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InfoItem;

--- a/app/performance/_components/toggle.tsx
+++ b/app/performance/_components/toggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Children, ReactNode } from 'react';
+import { Children, ReactNode, useEffect } from 'react';
 
 interface ToggleProps {
   className?: string;
@@ -24,6 +24,30 @@ const Toggle = ({
   const hasText = defaultText && toggledText;
 
   const [open, toggled] = childrenArray;
+
+  useEffect(() => {
+    try {
+      if ((defaultText && !toggledText) || (!defaultText && toggledText)) {
+        if (!defaultText) {
+          throw new Error('defaultText 입력해주세요');
+        } else {
+          throw new Error('toggledText 입력해주세요');
+        }
+      }
+
+      if (childrenArray.length !== 0 && hasText) {
+        throw new Error('chidren과 Text중 한 종류만 입력해주세요');
+      }
+
+      if (childrenArray.length && childrenArray.length !== 2) {
+        throw new Error('chidren 2개만 입력해주세요');
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
+  });
 
   if (hasText) {
     return (

--- a/app/performance/_components/toggle.tsx
+++ b/app/performance/_components/toggle.tsx
@@ -24,6 +24,7 @@ const Toggle = ({
   const hasText = defaultText && toggledText;
 
   const [open, toggled] = childrenArray;
+  const { length } = childrenArray;
 
   useEffect(() => {
     try {
@@ -35,11 +36,11 @@ const Toggle = ({
         }
       }
 
-      if (childrenArray.length !== 0 && hasText) {
+      if (length !== 0 && hasText) {
         throw new Error('chidren과 Text중 한 종류만 입력해주세요');
       }
 
-      if (childrenArray.length && childrenArray.length !== 2) {
+      if (length && length !== 2) {
         throw new Error('chidren 2개만 입력해주세요');
       }
     } catch (error) {
@@ -47,7 +48,7 @@ const Toggle = ({
         console.error(error.message);
       }
     }
-  });
+  }, [defaultText, toggledText, length, hasText]);
 
   if (hasText) {
     return (

--- a/app/performance/_components/toggle.tsx
+++ b/app/performance/_components/toggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Children, ReactNode } from 'react';
+
+interface ToggleProps {
+  className?: string;
+  isToggled: boolean;
+  onClick: () => void;
+  defaultText?: string;
+  toggledText?: string;
+  children?: ReactNode;
+}
+
+const Toggle = ({
+  className,
+  isToggled,
+  onClick,
+  defaultText = '',
+  toggledText = '',
+  children,
+}: ToggleProps) => {
+  const childrenArray = Children.toArray(children);
+
+  const hasText = defaultText && toggledText;
+
+  const [open, toggled] = childrenArray;
+
+  if (hasText) {
+    return (
+      <button className={className} onClick={onClick}>
+        {isToggled ? <span>{toggledText}</span> : <span>{defaultText}</span>}
+      </button>
+    );
+  }
+
+  return (
+    <button className={className} onClick={onClick}>
+      {isToggled ? toggled : open}
+    </button>
+  );
+};
+
+export default Toggle;

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,0 +1,111 @@
+import Image from 'next/image';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
+
+const Page = () => {
+  return (
+    <div className="mx-auto mt-8 flex flex-col gap-[54px] sm:w-[328px] md:w-[680px] lg:w-[890px]">
+      <h2 className="text-xl font-semibold">공연명</h2>
+      <div className="flex items-center gap-14 sm:flex-col">
+        <Image src={''} width={300} height={400} alt={`${'공연명'} 포스터`} />
+        <div className="flex w-full flex-col gap-4 px-3 pt-3">
+          <div className="flex sm:flex-col">
+            <span className="w-[90px] font-semibold">장소</span>
+            <span>장소명 (장소명) (장소명)</span>
+          </div>
+          <div className="flex sm:flex-col">
+            <span className="w-[90px] font-semibold">공연기간</span>
+            <span>2024.01.01&nbsp;~&nbsp;2024.01.01</span>
+          </div>
+          <div className="flex sm:flex-col">
+            <span className="w-[90px] font-semibold">공연시간</span>
+            <span>90분</span>
+          </div>
+          <div className="flex">
+            <span className="w-[90px] font-semibold">가격</span>
+            <div className="flex flex-col">
+              <span>30,000원</span>
+              <span>30,000원</span>
+              <span>30,000원</span>
+              <span>30,000원</span>
+              <span>30,000원</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <Tabs defaultValue="information">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="information">공연 정보</TabsTrigger>
+            <TabsTrigger value="recruitment">공연 구인 (0)</TabsTrigger>
+            <TabsTrigger value="review">관람 후기 (0)</TabsTrigger>
+          </TabsList>
+          <TabsContent
+            value="information"
+            className="flex w-full flex-col gap-6 p-6"
+          >
+            <div className="flex flex-col gap-4 sm:gap-1">
+              <span className="text-xl font-semibold">출연진</span>
+              <div>
+                <span>출연진1</span>
+                <span>출연진2</span>
+                <span>출연진3</span>
+              </div>
+            </div>
+            <div className="flex flex-col gap-4 sm:gap-1">
+              <span className="text-xl font-semibold">줄거리</span>
+              <div>
+                <p>줄거리 설명</p>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-6">
+              <div className="flex flex-col gap-4 sm:gap-1">
+                <span className="text-xl font-semibold">제작진</span>
+                <span>제작진</span>
+              </div>
+              <div className="flex flex-col gap-4 sm:gap-1">
+                <span className="text-xl font-semibold">기획사</span>
+                <span>기획사</span>
+              </div>
+              <div className="flex flex-col gap-4 sm:gap-1">
+                <span className="text-xl font-semibold">주최</span>
+                <span>주최</span>
+              </div>
+              <div className="flex flex-col gap-4 sm:gap-1">
+                <span className="text-xl font-semibold">주관</span>
+                <span>주관</span>
+              </div>
+            </div>
+            <div className="flex flex-col gap-4 sm:gap-1">
+              <span className="text-xl font-semibold">공연 시간</span>
+              <span>화요일 ~ 금요일 (20:00)</span>
+              <span>토요일 (20:00)</span>
+              <span>화요일 ~ 금요일 (10:00)</span>
+            </div>
+            <div className="flex flex-col gap-4 sm:gap-1">
+              <span className="text-xl font-semibold">공연 관람 연령</span>
+              <span>만 12세 이상</span>
+            </div>
+            <div className="flex flex-col gap-4 sm:gap-1">
+              <span className="text-xl font-semibold">공연 상세</span>
+              <Image
+                src={''}
+                width={840}
+                height={840}
+                alt={`${'공연명'} 포스터`}
+              />
+            </div>
+          </TabsContent>
+          <TabsContent value="recruitment">
+            <span>hi?</span>
+          </TabsContent>
+          <TabsContent value="review">
+            <span>hi?</span>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export default Page;

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,29 +1,74 @@
+import { VariantProps, cva } from 'class-variance-authority';
 import Image from 'next/image';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
 import { cn } from '~/libs/utils';
 
-interface InfoItemProps {
+const labelVariants = cva('', {
+  variants: {
+    width: {
+      default: '',
+      90: 'w-[90px]',
+    },
+    weight: {
+      default: '',
+      semibold: 'text-xl font-semibold',
+    },
+  },
+  defaultVariants: { width: 'default', weight: 'default' },
+});
+
+const contentVariants = cva('', {
+  variants: {
+    direction: {
+      default: '',
+      col: 'flex-col',
+    },
+    gap: {
+      default: '',
+      1: 'gap-1',
+    },
+    size: {
+      default: '',
+      sm: 'sm:flex-col',
+    },
+  },
+  defaultVariants: { direction: 'default', gap: 'default', size: 'default' },
+});
+
+interface InfoItemProps
+  extends VariantProps<typeof labelVariants>,
+    VariantProps<typeof contentVariants> {
   className?: string;
   label: string;
   contents: string[] | string;
   labelClassName?: string;
   contentClassName?: string;
+  children?: React.ReactNode;
 }
 
 const InfoItem = ({
   className,
   label,
   contents,
-  labelClassName,
-  contentClassName,
+  width,
+  weight,
+  direction,
+  gap,
+  children,
+  size,
 }: InfoItemProps) => {
   const isArray = typeof contents !== 'string';
 
   return (
     <div className={cn('flex', className)}>
-      <span className={cn('font-semibold', labelClassName)}>{label}</span>
-      <div className={cn('flex', contentClassName)}>
+      <div className="flex justify-between">
+        <span className={cn('font-semibold', labelVariants({ width, weight }))}>
+          {label}
+        </span>
+        {children}
+      </div>
+      <div className={cn('flex', contentVariants({ direction, gap, size }))}>
         {isArray ? (
           contents.map((text, index) => (
             <span key={`${text}_${index}`}>{text}</span>
@@ -46,20 +91,20 @@ const Page = () => {
           <InfoItem
             label={'장소'}
             className="sm:flex-col"
-            contents={'장소명 (장소명) (장소명)'}
-            labelClassName="w-[90px]"
+            contents={'장소명 (위치)'}
+            width={90}
           />
           <InfoItem
             label={'공연기간'}
             className="sm:flex-col"
             contents={'2024.01.01 ~ 2024.01.01'}
-            labelClassName="w-[90px]"
+            width={90}
           />
           <InfoItem
             label={'공연시간'}
             className="sm:flex-col"
             contents={'90분'}
-            labelClassName="w-[90px]"
+            width={90}
           />
           <InfoItem
             label={'가격'}
@@ -70,8 +115,8 @@ const Page = () => {
               '30,000원',
               '30,000원',
             ]}
-            labelClassName="w-[90px]"
-            contentClassName="flex-col"
+            width={90}
+            direction="col"
           />
         </div>
       </div>
@@ -90,44 +135,50 @@ const Page = () => {
               label={'출연진'}
               className="flex-col gap-4 sm:gap-1"
               contents={['출연진1', '출연진2', '출연진3']}
-              labelClassName="text-xl font-semibold"
-              contentClassName="gap-1"
+              weight="semibold"
+              gap={1}
             />
             <InfoItem
               label={'줄거리'}
               className="flex-col gap-4 sm:gap-1"
               contents={'줄거리 설명'}
-              labelClassName="text-xl font-semibold"
-            />
+              weight="semibold"
+            >
+              <button className="text-gray-300 md:hidden lg:hidden">
+                더보기
+              </button>
+            </InfoItem>
 
             <div className="grid grid-cols-2 gap-6">
               <InfoItem
                 label={'제작진'}
                 className="flex-col gap-4 sm:gap-1"
                 contents={['제작진', '제작진', '제작진']}
-                labelClassName="text-xl font-semibold"
-                contentClassName="gap-1"
+                weight="semibold"
+                gap={1}
+                size={'sm'}
               />
               <InfoItem
                 label={'기획사'}
                 className="flex-col gap-4 sm:gap-1"
                 contents={['기획사', '기획사', '기획사']}
-                labelClassName="text-xl font-semibold"
-                contentClassName="gap-1"
+                weight="semibold"
+                gap={1}
+                size={'sm'}
               />
               <InfoItem
                 label={'주최'}
                 className="flex-col gap-4 sm:gap-1"
                 contents={'주최'}
-                labelClassName="text-xl font-semibold"
-                contentClassName="gap-1"
+                weight="semibold"
+                gap={1}
               />
               <InfoItem
                 label={'주관'}
                 className="flex-col gap-4 sm:gap-1"
                 contents={'주관'}
-                labelClassName="text-xl font-semibold"
-                contentClassName="gap-1"
+                weight="semibold"
+                gap={1}
               />
             </div>
             <InfoItem
@@ -138,14 +189,14 @@ const Page = () => {
                 '토요일 (20:00)',
                 '화요일 ~ 금요일 (10:00)',
               ]}
-              labelClassName="text-xl font-semibold"
-              contentClassName="flex-col"
+              weight="semibold"
+              direction="col"
             />
             <InfoItem
               label={'공연 관람 연령'}
               className="flex-col gap-4 sm:gap-1"
               contents={'만 12세 이상'}
-              labelClassName="text-xl font-semibold"
+              weight="semibold"
             />
             <div className="flex flex-col gap-4 sm:gap-1">
               <span className="text-xl font-semibold">공연 상세</span>

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -2,7 +2,8 @@ import Image from 'next/image';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
 
-import InfoItem, { InfoItemWithButton } from './_components/info-item';
+import InfoItem from './_components/info-item';
+import InfoItemWithButton from './_components/info-item-with-button';
 
 const Page = () => {
   return (

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,85 +1,8 @@
-import { VariantProps, cva } from 'class-variance-authority';
 import Image from 'next/image';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
-import { cn } from '~/libs/utils';
 
-const labelVariants = cva('', {
-  variants: {
-    width: {
-      default: '',
-      90: 'w-[90px]',
-    },
-    weight: {
-      default: '',
-      semibold: 'text-xl font-semibold',
-    },
-  },
-  defaultVariants: { width: 'default', weight: 'default' },
-});
-
-const contentVariants = cva('', {
-  variants: {
-    direction: {
-      default: '',
-      col: 'flex-col',
-    },
-    gap: {
-      default: '',
-      1: 'gap-1',
-    },
-    size: {
-      default: '',
-      sm: 'sm:flex-col',
-    },
-  },
-  defaultVariants: { direction: 'default', gap: 'default', size: 'default' },
-});
-
-interface InfoItemProps
-  extends VariantProps<typeof labelVariants>,
-    VariantProps<typeof contentVariants> {
-  className?: string;
-  label: string;
-  contents: string[] | string;
-  labelClassName?: string;
-  contentClassName?: string;
-  children?: React.ReactNode;
-}
-
-const InfoItem = ({
-  className,
-  label,
-  contents,
-  width,
-  weight,
-  direction,
-  gap,
-  children,
-  size,
-}: InfoItemProps) => {
-  const isArray = typeof contents !== 'string';
-
-  return (
-    <div className={cn('flex', className)}>
-      <div className="flex justify-between">
-        <span className={cn('font-semibold', labelVariants({ width, weight }))}>
-          {label}
-        </span>
-        {children}
-      </div>
-      <div className={cn('flex', contentVariants({ direction, gap, size }))}>
-        {isArray ? (
-          contents.map((text, index) => (
-            <span key={`${text}_${index}`}>{text}</span>
-          ))
-        ) : (
-          <span>{contents}</span>
-        )}
-      </div>
-    </div>
-  );
-};
+import InfoItem from './_components/info-item';
 
 const Page = () => {
   return (

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,6 +1,40 @@
 import Image from 'next/image';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
+import { cn } from '~/libs/utils';
+
+interface InfoItemProps {
+  className?: string;
+  label: string;
+  contents: string[] | string;
+  labelClassName?: string;
+  contentClassName?: string;
+}
+
+const InfoItem = ({
+  className,
+  label,
+  contents,
+  labelClassName,
+  contentClassName,
+}: InfoItemProps) => {
+  const isArray = typeof contents !== 'string';
+
+  return (
+    <div className={cn('flex', className)}>
+      <span className={cn('font-semibold', labelClassName)}>{label}</span>
+      <div className={cn('flex', contentClassName)}>
+        {isArray ? (
+          contents.map((text, index) => (
+            <span key={`${text}_${index}`}>{text}</span>
+          ))
+        ) : (
+          <span>{contents}</span>
+        )}
+      </div>
+    </div>
+  );
+};
 
 const Page = () => {
   return (
@@ -9,83 +43,110 @@ const Page = () => {
       <div className="flex items-center gap-14 sm:flex-col">
         <Image src={''} width={300} height={400} alt={`${'공연명'} 포스터`} />
         <div className="flex w-full flex-col gap-4 px-3 pt-3">
-          <div className="flex sm:flex-col">
-            <span className="w-[90px] font-semibold">장소</span>
-            <span>장소명 (장소명) (장소명)</span>
-          </div>
-          <div className="flex sm:flex-col">
-            <span className="w-[90px] font-semibold">공연기간</span>
-            <span>2024.01.01&nbsp;~&nbsp;2024.01.01</span>
-          </div>
-          <div className="flex sm:flex-col">
-            <span className="w-[90px] font-semibold">공연시간</span>
-            <span>90분</span>
-          </div>
-          <div className="flex">
-            <span className="w-[90px] font-semibold">가격</span>
-            <div className="flex flex-col">
-              <span>30,000원</span>
-              <span>30,000원</span>
-              <span>30,000원</span>
-              <span>30,000원</span>
-              <span>30,000원</span>
-            </div>
-          </div>
+          <InfoItem
+            label={'장소'}
+            className="sm:flex-col"
+            contents={'장소명 (장소명) (장소명)'}
+            labelClassName="w-[90px]"
+          />
+          <InfoItem
+            label={'공연기간'}
+            className="sm:flex-col"
+            contents={'2024.01.01 ~ 2024.01.01'}
+            labelClassName="w-[90px]"
+          />
+          <InfoItem
+            label={'공연시간'}
+            className="sm:flex-col"
+            contents={'90분'}
+            labelClassName="w-[90px]"
+          />
+          <InfoItem
+            label={'가격'}
+            contents={[
+              '30,000원',
+              '30,000원',
+              '30,000원',
+              '30,000원',
+              '30,000원',
+            ]}
+            labelClassName="w-[90px]"
+            contentClassName="flex-col"
+          />
         </div>
       </div>
       <div>
         <Tabs defaultValue="information">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="information">공연 정보</TabsTrigger>
-            <TabsTrigger value="recruitment">공연 구인 (0)</TabsTrigger>
-            <TabsTrigger value="review">관람 후기 (0)</TabsTrigger>
+            <TabsTrigger value="recruitment">공연 구인 ({0})</TabsTrigger>
+            <TabsTrigger value="review">관람 후기 ({0})</TabsTrigger>
           </TabsList>
           <TabsContent
             value="information"
             className="flex w-full flex-col gap-6 p-6"
           >
-            <div className="flex flex-col gap-4 sm:gap-1">
-              <span className="text-xl font-semibold">출연진</span>
-              <div>
-                <span>출연진1</span>
-                <span>출연진2</span>
-                <span>출연진3</span>
-              </div>
-            </div>
-            <div className="flex flex-col gap-4 sm:gap-1">
-              <span className="text-xl font-semibold">줄거리</span>
-              <div>
-                <p>줄거리 설명</p>
-              </div>
-            </div>
+            <InfoItem
+              label={'출연진'}
+              className="flex-col gap-4 sm:gap-1"
+              contents={['출연진1', '출연진2', '출연진3']}
+              labelClassName="text-xl font-semibold"
+              contentClassName="gap-1"
+            />
+            <InfoItem
+              label={'줄거리'}
+              className="flex-col gap-4 sm:gap-1"
+              contents={'줄거리 설명'}
+              labelClassName="text-xl font-semibold"
+            />
+
             <div className="grid grid-cols-2 gap-6">
-              <div className="flex flex-col gap-4 sm:gap-1">
-                <span className="text-xl font-semibold">제작진</span>
-                <span>제작진</span>
-              </div>
-              <div className="flex flex-col gap-4 sm:gap-1">
-                <span className="text-xl font-semibold">기획사</span>
-                <span>기획사</span>
-              </div>
-              <div className="flex flex-col gap-4 sm:gap-1">
-                <span className="text-xl font-semibold">주최</span>
-                <span>주최</span>
-              </div>
-              <div className="flex flex-col gap-4 sm:gap-1">
-                <span className="text-xl font-semibold">주관</span>
-                <span>주관</span>
-              </div>
+              <InfoItem
+                label={'제작진'}
+                className="flex-col gap-4 sm:gap-1"
+                contents={['제작진', '제작진', '제작진']}
+                labelClassName="text-xl font-semibold"
+                contentClassName="gap-1"
+              />
+              <InfoItem
+                label={'기획사'}
+                className="flex-col gap-4 sm:gap-1"
+                contents={['기획사', '기획사', '기획사']}
+                labelClassName="text-xl font-semibold"
+                contentClassName="gap-1"
+              />
+              <InfoItem
+                label={'주최'}
+                className="flex-col gap-4 sm:gap-1"
+                contents={'주최'}
+                labelClassName="text-xl font-semibold"
+                contentClassName="gap-1"
+              />
+              <InfoItem
+                label={'주관'}
+                className="flex-col gap-4 sm:gap-1"
+                contents={'주관'}
+                labelClassName="text-xl font-semibold"
+                contentClassName="gap-1"
+              />
             </div>
-            <div className="flex flex-col gap-4 sm:gap-1">
-              <span className="text-xl font-semibold">공연 시간</span>
-              <span>화요일 ~ 금요일 (20:00)</span>
-              <span>토요일 (20:00)</span>
-              <span>화요일 ~ 금요일 (10:00)</span>
-            </div>
-            <div className="flex flex-col gap-4 sm:gap-1">
-              <span className="text-xl font-semibold">공연 관람 연령</span>
-              <span>만 12세 이상</span>
-            </div>
+            <InfoItem
+              label={'공연 시간'}
+              className="flex-col gap-4 sm:gap-1"
+              contents={[
+                '화요일 ~ 금요일 (20:00)',
+                '토요일 (20:00)',
+                '화요일 ~ 금요일 (10:00)',
+              ]}
+              labelClassName="text-xl font-semibold"
+              contentClassName="flex-col"
+            />
+            <InfoItem
+              label={'공연 관람 연령'}
+              className="flex-col gap-4 sm:gap-1"
+              contents={'만 12세 이상'}
+              labelClassName="text-xl font-semibold"
+            />
             <div className="flex flex-col gap-4 sm:gap-1">
               <span className="text-xl font-semibold">공연 상세</span>
               <Image
@@ -97,10 +158,10 @@ const Page = () => {
             </div>
           </TabsContent>
           <TabsContent value="recruitment">
-            <span>hi?</span>
+            <span>공연 구인</span>
           </TabsContent>
           <TabsContent value="review">
-            <span>hi?</span>
+            <span>관람 후기</span>
           </TabsContent>
         </Tabs>
       </div>

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
 
-import InfoItem from './_components/info-item';
+import InfoItem, { InfoItemWithButton } from './_components/info-item';
 
 const Page = () => {
   return (
@@ -61,16 +61,17 @@ const Page = () => {
               weight="semibold"
               gap={1}
             />
-            <InfoItem
+            <InfoItemWithButton
               label={'줄거리'}
               className="flex-col gap-4 sm:gap-1"
-              contents={'줄거리 설명'}
+              contents={
+                '줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명'
+              }
               weight="semibold"
             >
-              <button className="text-gray-300 md:hidden lg:hidden">
-                더보기
-              </button>
-            </InfoItem>
+              <span>더 보기</span>
+              <span>접기</span>
+            </InfoItemWithButton>
 
             <div className="grid grid-cols-2 gap-6">
               <InfoItem

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
 
 import InfoItem from './_components/info-item';
-import InfoItemWithButton from './_components/info-item-with-button';
+import InfoItemWithToggle from './_components/info-item-with-button';
 
 const Page = () => {
   return (
@@ -62,17 +62,16 @@ const Page = () => {
               weight="semibold"
               gap={1}
             />
-            <InfoItemWithButton
+            <InfoItemWithToggle
               label={'줄거리'}
               className="flex-col gap-4 sm:gap-1"
               contents={
                 '줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명줄거리 설명'
               }
               weight="semibold"
-            >
-              <span>더 보기</span>
-              <span>접기</span>
-            </InfoItemWithButton>
+              defaultText="더보기"
+              toggledText="접기"
+            />
 
             <div className="grid grid-cols-2 gap-6">
               <InfoItem

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -16,19 +16,19 @@ const Page = () => {
             label={'장소'}
             className="sm:flex-col"
             contents={'장소명 (위치)'}
-            width={90}
+            labelWidth={'w-[90px]'}
           />
           <InfoItem
             label={'공연기간'}
             className="sm:flex-col"
             contents={'2024.01.01 ~ 2024.01.01'}
-            width={90}
+            labelWidth={'w-[90px]'}
           />
           <InfoItem
             label={'공연시간'}
             className="sm:flex-col"
             contents={'90분'}
-            width={90}
+            labelWidth={'w-[90px]'}
           />
           <InfoItem
             label={'가격'}
@@ -39,7 +39,7 @@ const Page = () => {
               '30,000원',
               '30,000원',
             ]}
-            width={90}
+            labelWidth={'w-[90px]'}
             direction="col"
           />
         </div>
@@ -60,7 +60,7 @@ const Page = () => {
               className="flex-col gap-4 sm:gap-1"
               contents={['출연진1', '출연진2', '출연진3']}
               weight="semibold"
-              gap={1}
+              contentGap={'gap-1'}
             />
             <InfoItemWithToggle
               label={'줄거리'}
@@ -79,7 +79,7 @@ const Page = () => {
                 className="flex-col gap-4 sm:gap-1"
                 contents={['제작진', '제작진', '제작진']}
                 weight="semibold"
-                gap={1}
+                contentGap={'gap-1'}
                 size={'sm'}
               />
               <InfoItem
@@ -87,7 +87,7 @@ const Page = () => {
                 className="flex-col gap-4 sm:gap-1"
                 contents={['기획사', '기획사', '기획사']}
                 weight="semibold"
-                gap={1}
+                contentGap={'gap-1'}
                 size={'sm'}
               />
               <InfoItem
@@ -95,14 +95,14 @@ const Page = () => {
                 className="flex-col gap-4 sm:gap-1"
                 contents={'주최'}
                 weight="semibold"
-                gap={1}
+                contentGap={'gap-1'}
               />
               <InfoItem
                 label={'주관'}
                 className="flex-col gap-4 sm:gap-1"
                 contents={'주관'}
                 weight="semibold"
-                gap={1}
+                contentGap={'gap-1'}
               />
             </div>
             <InfoItem


### PR DESCRIPTION
<!-- pr 제목은 아래와 같이 작성해주세요. -->
<!-- Commit Type: [#이슈 번호] 이슈 제목과 동일한 제목 -->

## 📝 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
공연 정보 페이지 UI를 추가했습니다.
- [x] 구조를 먼저 잡았습니다.
- [x] 중복되는 코드를 InfoItem컴포넌트로 분리했습니다.
- [x] cva로 label, content의 classname에 활용했습니다.
- [x] 더보기 및 접기 버튼은 state로 관리합니다. 현재 토글이 가능합니다.
- [x] 더보기 버튼은 모바일 (sm)에서만 활성화 됩니다.
- [x] 화면 크기 (sm, md, lg)를 반영했습니다.
- [x] UI Task만 진행했습니다. 그래서 이미지 및 다른 데이터들은 이후 Task에서 교체할 예정입니다.

- close #99 

## 📷 스크린샷 (선택)
### [PC 화면]
![image](https://github.com/GoGo-Ring/dongoorami-frontend/assets/86847564/8467ffeb-bd15-4c06-a618-5aa4ecb2af96)

### [모바일]: 줄거리 접은 화면
![image](https://github.com/GoGo-Ring/dongoorami-frontend/assets/86847564/9518a5fd-c163-4b9a-8d18-831e425cee52)

### [모바일]: 줄거리 펼친 화면
![image](https://github.com/GoGo-Ring/dongoorami-frontend/assets/86847564/13b89b07-a5cf-4cfa-beab-d05d46adb07f)


## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
