### PR TITLE
Style: [#159] 검색 페이지 UI 수정

### DIFF
--- a/app/_components/filter-tabs.tsx
+++ b/app/_components/filter-tabs.tsx
@@ -9,12 +9,14 @@ import PerformanceFilter from './performance-filter';
 
 interface FilterTabsProps {
   baseUrl?: string;
+  className?: string;
   hasFilterTitle?: boolean;
 }
 
 const FilterTabs = ({
   baseUrl = 'search',
   hasFilterTitle = true,
+  className = '',
 }: FilterTabsProps) => {
   const router = useRouter();
 
@@ -23,7 +25,7 @@ const FilterTabs = ({
   };
 
   return (
-    <div className="flex w-[300px] flex-col gap-3">
+    <div className={`flex w-[300px] flex-col gap-3 ${className}`}>
       {hasFilterTitle && (
         <div className="flex gap-3 p-3">
           <Icon iconName="filter" />

--- a/app/_components/filter-tabs.tsx
+++ b/app/_components/filter-tabs.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import Icon from '~/components/icon';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/tabs';
+import { cn } from '~/libs/utils';
 
 import CompanionRecruitmentFilter from './companion-recruitment-filter';
 import PerformanceFilter from './performance-filter';
@@ -25,7 +26,7 @@ const FilterTabs = ({
   };
 
   return (
-    <div className={`flex w-[300px] flex-col gap-3 ${className}`}>
+    <div className={cn('flex w-[300px] flex-col gap-3', className)}>
       {hasFilterTitle && (
         <div className="flex gap-3 p-3">
           <Icon iconName="filter" />

--- a/app/search/_component/filter-search.tsx
+++ b/app/search/_component/filter-search.tsx
@@ -56,7 +56,7 @@ const FilterSearch = () => {
       <div className=" box-border py-5">
         <FilterTabs className="sticky top-24 -z-10" />
       </div>
-      <div className="-z-10 flex shrink-0 flex-col gap-8 py-10 sm:w-[328px] md:w-[400px] lg:w-[700px]">
+      <div className="flex shrink-0 flex-col gap-8 py-10 sm:w-[328px] md:w-[400px] lg:w-[700px]">
         {performancesData && (
           <PerformanceInfoList
             data={performancesData}

--- a/app/search/_component/filter-search.tsx
+++ b/app/search/_component/filter-search.tsx
@@ -52,11 +52,11 @@ const FilterSearch = () => {
   }, [params]);
 
   return (
-    <div className="flex">
-      <div className="box-border py-5">
-        <FilterTabs />
+    <div className="relative flex  h-fit">
+      <div className=" box-border py-5">
+        <FilterTabs className="sticky top-24 -z-10" />
       </div>
-      <div className="flex flex-col gap-8 px-6 py-10">
+      <div className="-z-10 flex shrink-0 flex-col gap-8 py-10 sm:w-[328px] md:w-[400px] lg:w-[700px]">
         {performancesData && (
           <PerformanceInfoList
             data={performancesData}

--- a/app/search/_component/performance-info-list.tsx
+++ b/app/search/_component/performance-info-list.tsx
@@ -25,7 +25,7 @@ const PerformanceInfoList = ({
     <>
       <div className="flex flex-col gap-6">
         <h3 className="font-semibold">공연</h3>
-        <div className="mx-auto grid grid-cols-3">
+        <div className="mx-auto grid sm:grid-cols-1 md:grid-cols-1 lg:grid-cols-3">
           {data?.pages?.map(page =>
             page.concertGetShortResponses?.map(({ status, id, ...rest }) => (
               <PerformanceInfoCard


### PR DESCRIPTION
<!-- pr 제목은 아래와 같이 작성해주세요. -->
<!-- Commit Type: [#이슈 번호] 이슈 제목과 동일한 제목 -->

## 📝 작업 내용
- `검색 페이지` UI를 수정했습니다.
- `공연 상세` 페이지 UI는 TASK 를 나누어서 작업하려고 합니다. 
    - PR 152 머지 이후 수정하겠습니다.

- 요소 간 겹치지 않도록 width 수정
    - sm, md, lg로나누어 width를 각각 할당했습니다.
    - sm, md일 때 그리드 컬럼을 1로 지정했습니다.
- filter-tabs 컴포넌트에 className 을 prop으로 지정했습니다.
    - 페이지 좌측 상단에 고정되도록 sticky 속성을 부여했습니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- close #159

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
