### PR TITLE
Feat: [#151] 메인페이지 기능 추가 및 스타일

### DIFF
--- a/apis/performance.ts
+++ b/apis/performance.ts
@@ -47,3 +47,14 @@ export const getPerformancesList = async (
 
   return data;
 };
+
+export const getCarouselPerformances = async () => {
+  const { data } = await api.get<PerformanceList>({
+    url: '/concerts',
+    params: {
+      size: 6,
+    },
+  });
+
+  return data;
+};

--- a/app/_components/MainFilter.tsx
+++ b/app/_components/MainFilter.tsx
@@ -2,12 +2,14 @@ import CompanionRecruitmentFilter from './companion-recruitment-filter';
 
 const MainFilter = () => {
   return (
-    <div className="flex w-[220px] justify-center border p-8 sm:hidden">
-      <CompanionRecruitmentFilter
-        onSubmit={() => {
-          return 1;
-        }}
-      />
+    <div className="border  sm:hidden">
+      <div className="sticky top-0 flex h-[900px] w-[220px] justify-center p-4">
+        <CompanionRecruitmentFilter
+          onSubmit={() => {
+            return 1;
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/app/_components/MainFilter.tsx
+++ b/app/_components/MainFilter.tsx
@@ -3,7 +3,7 @@ import CompanionRecruitmentFilter from './companion-recruitment-filter';
 const MainFilter = () => {
   return (
     <div className="border  sm:hidden">
-      <div className="sticky top-0 flex h-[900px] w-[220px] justify-center p-4">
+      <div className="sticky top-[50px] flex h-[900px] w-[220px] justify-center p-4">
         <CompanionRecruitmentFilter
           onSubmit={() => {
             return 1;

--- a/app/_components/MobileFilter.tsx
+++ b/app/_components/MobileFilter.tsx
@@ -11,14 +11,14 @@ const MobileFilter = () => {
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
       <SheetTrigger asChild>
-        <div className="fixed bottom-5 left-5 hidden sm:block">
+        <div className="fixed bottom-4 left-4 hidden sm:absolute sm:bottom-0 sm:bottom-16 sm:left-0 sm:block">
           <Icon
-            className="h-[35px] w-[35px] cursor-pointer"
+            className="fixed h-[35px] w-[35px] cursor-pointer"
             iconName="filter"
           />
         </div>
       </SheetTrigger>
-      <SheetContent side="left">
+      <SheetContent side="left" className="overflow-scroll">
         <div className="flex w-full justify-center border p-8">
           <CompanionRecruitmentFilter
             onSubmit={() => {

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import {
@@ -14,21 +15,21 @@ interface StyledCarouselProps {
 }
 
 const StyledCarousel = ({ performances }: StyledCarouselProps) => {
-  const images = performances.map(performance => performance.poster);
-
   return (
     <Carousel className="flex w-full justify-center border py-8 sm:aspect-square">
       <CarouselContent className="flex">
-        {images.map((image, index) => (
+        {performances.map((performance, index) => (
           <CarouselItem className=" flex justify-center " key={index}>
             <div className="flex w-[350px] justify-center border p-2">
-              <Image
-                width={500}
-                height={288}
-                className="h-full w-full "
-                src={image}
-                alt={`${image} 포스터`}
-              />
+              <Link href={`/performance/${performance.id}`}>
+                <Image
+                  width={500}
+                  height={288}
+                  className="h-full w-full "
+                  src={performance.poster}
+                  alt={`${performance.name}} 포스터`}
+                />
+              </Link>
             </div>
           </CarouselItem>
         ))}

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -1,3 +1,6 @@
+import Image from 'next/image';
+
+import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import {
   Carousel,
   CarouselContent,
@@ -6,13 +9,30 @@ import {
   CarouselPrevious,
 } from '~/components/carousel';
 
-const StyledCarousel = () => {
+interface StyledCarouselProps {
+  datas: PerformanceInfoListItemApi[];
+}
+
+const StyledCarousel = ({ datas }: StyledCarouselProps) => {
+  const images = datas.map(data => data.poster);
+
   return (
-    <Carousel className="flex aspect-carousel w-full justify-center border py-8 sm:aspect-square">
+    <Carousel className="flex aspect-carousel w-[300] justify-center border py-8 sm:aspect-square">
       <CarouselContent className="flex">
-        {Array.from({ length: 3 }).map((_, index) => (
+        {/* {Array.from({ length: 3 }).map((_, index) => (
           <CarouselItem key={index}>
             <div className="h-full w-full bg-primary">{index}번 공연 정보</div>
+          </CarouselItem>
+        ))} */}
+        {images.map((image, index) => (
+          <CarouselItem key={index}>
+            <Image
+              width={224}
+              height={288}
+              className="h-full w-full "
+              src={image}
+              alt={`${image} 포스터`}
+            />
           </CarouselItem>
         ))}
       </CarouselContent>

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -18,7 +18,7 @@ interface StyledCarouselProps {
 
 const StyledCarousel = ({ performances }: StyledCarouselProps) => {
   return (
-    <Carousel className="flex w-full justify-center border py-8 sm:aspect-square">
+    <Carousel className="flex w-full justify-center border py-8">
       {performances ? (
         <>
           <CarouselContent className="flex">

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Suspense } from 'react';
 
 import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import {
@@ -9,33 +10,46 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from '~/components/carousel';
+import Spinner from '~/components/spinner';
 
 interface StyledCarouselProps {
-  performances: PerformanceInfoListItemApi[];
+  performances: PerformanceInfoListItemApi[] | null;
 }
 
 const StyledCarousel = ({ performances }: StyledCarouselProps) => {
   return (
     <Carousel className="flex w-full justify-center border py-8 sm:aspect-square">
-      <CarouselContent className="flex">
-        {performances.map((performance, index) => (
-          <CarouselItem className=" flex justify-center " key={index}>
-            <div className="flex w-[350px] justify-center border p-2">
-              <Link href={`/performance/${performance.id}`}>
-                <Image
-                  width={500}
-                  height={288}
-                  className="h-full w-full "
-                  src={performance.poster}
-                  alt={`${performance.name}} 포스터`}
-                />
-              </Link>
-            </div>
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselPrevious />
-      <CarouselNext />
+      {performances ? (
+        <>
+          <CarouselContent className="flex">
+            {performances.map((performance, index) => (
+              <Suspense key={index} fallback={<Spinner />}>
+                <CarouselItem className=" flex justify-center " key={index}>
+                  <div className="flex w-[350px] justify-center border p-2">
+                    <Link href={`/performance/${performance.id}`}>
+                      <Image
+                        width={500}
+                        height={288}
+                        className="h-full w-full "
+                        src={performance.poster}
+                        alt={`${performance.name}} 포스터`}
+                      />
+                    </Link>
+                  </div>
+                </CarouselItem>
+              </Suspense>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </>
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <CarouselContent className="flex h-[500px] w-full items-center justify-center">
+            <Spinner />
+          </CarouselContent>
+        </div>
+      )}
     </Carousel>
   );
 };

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -13,7 +13,7 @@ import {
 import Spinner from '~/components/spinner';
 
 interface StyledCarouselProps {
-  performances: PerformanceInfoListItemApi[] | null;
+  performances: PerformanceInfoListItemApi[] | undefined;
 }
 
 const StyledCarousel = ({ performances }: StyledCarouselProps) => {

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -26,7 +26,7 @@ const StyledCarousel = ({ datas }: StyledCarouselProps) => {
         ))} */}
         {images.map((image, index) => (
           <CarouselItem className=" flex justify-center " key={index}>
-            <div className="bg-red flex w-[350px] justify-center border p-8">
+            <div className="flex w-[350px] justify-center border p-2">
               <Image
                 width={500}
                 height={288}

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -17,7 +17,7 @@ const StyledCarousel = ({ datas }: StyledCarouselProps) => {
   const images = datas.map(data => data.poster);
 
   return (
-    <Carousel className="flex aspect-carousel w-[300] justify-center border py-8 sm:aspect-square">
+    <Carousel className="flex w-full justify-center border py-8 sm:aspect-square">
       <CarouselContent className="flex">
         {/* {Array.from({ length: 3 }).map((_, index) => (
           <CarouselItem key={index}>
@@ -25,14 +25,16 @@ const StyledCarousel = ({ datas }: StyledCarouselProps) => {
           </CarouselItem>
         ))} */}
         {images.map((image, index) => (
-          <CarouselItem key={index}>
-            <Image
-              width={224}
-              height={288}
-              className="h-full w-full "
-              src={image}
-              alt={`${image} 포스터`}
-            />
+          <CarouselItem className=" flex justify-center " key={index}>
+            <div className="bg-red flex w-[350px] justify-center border p-8">
+              <Image
+                width={500}
+                height={288}
+                className="h-full w-full "
+                src={image}
+                alt={`${image} 포스터`}
+              />
+            </div>
           </CarouselItem>
         ))}
       </CarouselContent>

--- a/app/_components/StyledCarousel.tsx
+++ b/app/_components/StyledCarousel.tsx
@@ -10,20 +10,15 @@ import {
 } from '~/components/carousel';
 
 interface StyledCarouselProps {
-  datas: PerformanceInfoListItemApi[];
+  performances: PerformanceInfoListItemApi[];
 }
 
-const StyledCarousel = ({ datas }: StyledCarouselProps) => {
-  const images = datas.map(data => data.poster);
+const StyledCarousel = ({ performances }: StyledCarouselProps) => {
+  const images = performances.map(performance => performance.poster);
 
   return (
     <Carousel className="flex w-full justify-center border py-8 sm:aspect-square">
       <CarouselContent className="flex">
-        {/* {Array.from({ length: 3 }).map((_, index) => (
-          <CarouselItem key={index}>
-            <div className="h-full w-full bg-primary">{index}번 공연 정보</div>
-          </CarouselItem>
-        ))} */}
         {images.map((image, index) => (
           <CarouselItem className=" flex justify-center " key={index}>
             <div className="flex w-[350px] justify-center border p-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from 'react';
 import { getPerformancesList } from '~/apis/performance';
 import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import CompanionRecruitmentList from '~/app/search/_component/companion-recruitment-list';
-import { Button } from '~/components/button';
 import useInfiniteAccompanies from '~/hooks/infinite/useInfiniteAccompanies';
 
 import MainFilter from './_components/MainFilter';
@@ -13,7 +12,6 @@ import MobileFilter from './_components/MobileFilter';
 import StyledCarousel from './_components/StyledCarousel';
 
 const Page = () => {
-  const [isMoreCompanionInfinite, setIsMoreCompanionInfinite] = useState(false);
   const [performancesData, setPerformancesData] = useState<
     PerformanceInfoListItemApi[] | null
   >(null);
@@ -45,19 +43,10 @@ const Page = () => {
           {accompaniesData && (
             <CompanionRecruitmentList
               data={accompaniesData}
-              isInfinite={isMoreCompanionInfinite}
+              isInfinite={true}
               hasNextPage={hasNextPageCompanion}
               handleFetchNextPage={() => fetchNextAccompaniesPage()}
             />
-          )}
-          {!isMoreCompanionInfinite && (
-            <Button
-              variant="outline"
-              onClick={() => setIsMoreCompanionInfinite(true)}
-              disabled={isMoreCompanionInfinite}
-            >
-              동행 모집 더보기
-            </Button>
           )}
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { getPerformancesList } from '~/apis/performance';
+import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import CompanionRecruitmentList from '~/app/search/_component/companion-recruitment-list';
 import { Button } from '~/components/button';
 import useInfiniteAccompanies from '~/hooks/infinite/useInfiniteAccompanies';
@@ -12,15 +14,31 @@ import StyledCarousel from './_components/StyledCarousel';
 
 const Page = () => {
   const [isMoreCompanionInfinite, setIsMoreCompanionInfinite] = useState(false);
+  const [performancesData, setPerformancesData] = useState<
+    PerformanceInfoListItemApi[] | null
+  >(null);
+
   const {
     data: accompaniesData,
     fetchNextPage: fetchNextAccompaniesPage,
     hasNextPage: hasNextPageCompanion,
   } = useInfiniteAccompanies('');
 
+  const fetchPerformances = async () => {
+    const { concertGetShortResponses } = await getPerformancesList('', 6, 0);
+
+    setPerformancesData(concertGetShortResponses);
+  };
+
+  useEffect(() => {
+    fetchPerformances();
+  }, []);
+
   return (
-    <div>
-      <StyledCarousel />
+    <div className="flex flex-col ">
+      <div className="flex w-[500px]  border">
+        {performancesData && <StyledCarousel datas={performancesData} />}
+      </div>
       <div className="flex w-full border">
         <MainFilter />
         {accompaniesData && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,8 +11,8 @@ const Page = () => {
       <StyledCarousel />
       <div className="flex w-full border">
         <MainFilter />
-        <div className="grid w-full grid-cols-3 gap-8 border p-8 sm:grid-cols-1 mainmd:grid-cols-2">
-          {Array.from({ length: 9 }).map((_, index) => (
+        <div className=" grid w-full grid-cols-3 gap-8 border p-8 sm:grid-cols-1 mainmd:grid-cols-2">
+          {Array.from({ length: 100 }).map((_, index) => (
             <DummyCard key={index} />
           ))}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,46 @@
 'use client';
 
-import { DummyCard } from './_components/DummyCard';
+import { useState } from 'react';
+
+import CompanionRecruitmentList from '~/app/search/_component/companion-recruitment-list';
+import { Button } from '~/components/button';
+import useInfiniteAccompanies from '~/hooks/infinite/useInfiniteAccompanies';
+
 import MainFilter from './_components/MainFilter';
 import MobileFilter from './_components/MobileFilter';
 import StyledCarousel from './_components/StyledCarousel';
 
 const Page = () => {
+  const [isMoreCompanionInfinite, setIsMoreCompanionInfinite] = useState(false);
+  const {
+    data: accompaniesData,
+    fetchNextPage: fetchNextAccompaniesPage,
+    hasNextPage: hasNextPageCompanion,
+  } = useInfiniteAccompanies('');
+
   return (
     <div>
       <StyledCarousel />
       <div className="flex w-full border">
         <MainFilter />
-        <div className=" grid w-full grid-cols-3 gap-8 border p-8 sm:grid-cols-1 mainmd:grid-cols-2">
-          {Array.from({ length: 100 }).map((_, index) => (
-            <DummyCard key={index} />
-          ))}
-        </div>
+        {accompaniesData && (
+          <CompanionRecruitmentList
+            data={accompaniesData}
+            isInfinite={isMoreCompanionInfinite}
+            hasNextPage={hasNextPageCompanion}
+            handleFetchNextPage={() => fetchNextAccompaniesPage()}
+          />
+        )}
       </div>
+      {!isMoreCompanionInfinite && (
+        <Button
+          variant="outline"
+          onClick={() => setIsMoreCompanionInfinite(true)}
+          disabled={isMoreCompanionInfinite}
+        >
+          동행 모집 더보기
+        </Button>
+      )}
       <MobileFilter />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ const Page = () => {
 
   return (
     <div className="flex flex-col ">
-      <div className="flex w-[500px]  border">
+      <div className="flex w-full  border">
         {performancesData && <StyledCarousel datas={performancesData} />}
       </div>
       <div className="flex w-full border">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useState } from 'react';
 
-import { getPerformancesList } from '~/apis/performance';
 import { PerformanceInfoListItemApi } from '~/apis/scheme/performance';
 import CompanionRecruitmentList from '~/app/search/_component/companion-recruitment-list';
 import useInfiniteAccompanies from '~/hooks/infinite/useInfiniteAccompanies';
+import { useFetchCarouselPerformances } from '~/hooks/queries/useFetchCarouselPerformances';
 
 import MainFilter from './_components/MainFilter';
 import MobileFilter from './_components/MobileFilter';
@@ -13,8 +13,8 @@ import StyledCarousel from './_components/StyledCarousel';
 
 const Page = () => {
   const [performancesData, setPerformancesData] = useState<
-    PerformanceInfoListItemApi[] | null
-  >(null);
+    PerformanceInfoListItemApi[] | undefined
+  >(undefined);
 
   const {
     data: accompaniesData,
@@ -22,15 +22,13 @@ const Page = () => {
     hasNextPage: hasNextPageCompanion,
   } = useInfiniteAccompanies('', 9);
 
-  const fetchPerformances = async () => {
-    const { concertGetShortResponses } = await getPerformancesList('', 6, 0);
-
-    setPerformancesData(concertGetShortResponses);
-  };
+  const { data } = useFetchCarouselPerformances();
 
   useEffect(() => {
-    fetchPerformances();
-  }, []);
+    if (data) {
+      setPerformancesData(data.concertGetShortResponses);
+    }
+  }, [data]);
 
   return (
     <div className="flex flex-col ">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ const Page = () => {
   return (
     <div className="flex flex-col ">
       <div className="flex w-full  border">
-        {performancesData && <StyledCarousel datas={performancesData} />}
+        {performancesData && <StyledCarousel performances={performancesData} />}
       </div>
       <div className="flex w-full border">
         <MainFilter />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -35,7 +35,7 @@ const Page = () => {
   return (
     <div className="flex flex-col ">
       <div className="flex w-full  border">
-        {performancesData && <StyledCarousel performances={performancesData} />}
+        <StyledCarousel performances={performancesData} />
       </div>
       <div className="flex w-full border">
         <MainFilter />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ const Page = () => {
     data: accompaniesData,
     fetchNextPage: fetchNextAccompaniesPage,
     hasNextPage: hasNextPageCompanion,
-  } = useInfiniteAccompanies('');
+  } = useInfiniteAccompanies('', 9);
 
   const fetchPerformances = async () => {
     const { concertGetShortResponses } = await getPerformancesList('', 6, 0);
@@ -41,24 +41,27 @@ const Page = () => {
       </div>
       <div className="flex w-full border">
         <MainFilter />
-        {accompaniesData && (
-          <CompanionRecruitmentList
-            data={accompaniesData}
-            isInfinite={isMoreCompanionInfinite}
-            hasNextPage={hasNextPageCompanion}
-            handleFetchNextPage={() => fetchNextAccompaniesPage()}
-          />
-        )}
+        <div className="flex w-full flex-col justify-start gap-4 p-4">
+          {accompaniesData && (
+            <CompanionRecruitmentList
+              data={accompaniesData}
+              isInfinite={isMoreCompanionInfinite}
+              hasNextPage={hasNextPageCompanion}
+              handleFetchNextPage={() => fetchNextAccompaniesPage()}
+            />
+          )}
+          {!isMoreCompanionInfinite && (
+            <Button
+              variant="outline"
+              onClick={() => setIsMoreCompanionInfinite(true)}
+              disabled={isMoreCompanionInfinite}
+            >
+              동행 모집 더보기
+            </Button>
+          )}
+        </div>
       </div>
-      {!isMoreCompanionInfinite && (
-        <Button
-          variant="outline"
-          onClick={() => setIsMoreCompanionInfinite(true)}
-          disabled={isMoreCompanionInfinite}
-        >
-          동행 모집 더보기
-        </Button>
-      )}
+
       <MobileFilter />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,7 +48,6 @@ const Page = () => {
           )}
         </div>
       </div>
-
       <MobileFilter />
     </div>
   );

--- a/app/search/_component/companion-recruitment-list.tsx
+++ b/app/search/_component/companion-recruitment-list.tsx
@@ -25,7 +25,7 @@ const CompanionRecruitmentList = ({
   return (
     <div className="flex w-full flex-col gap-6">
       <span className="font-semibold">동행 모집</span>
-      <div className="grid w-full grid-cols-3 ">
+      <div className="grid w-full grid-cols-3 sm:grid-cols-1 mainmd:grid-cols-2 ">
         {data.pages?.map(page =>
           page?.accompanyPostInfos.map(({ id, status, gender, ...rest }) => (
             <CompanionRecruitmentCard

--- a/app/search/_component/companion-recruitment-list.tsx
+++ b/app/search/_component/companion-recruitment-list.tsx
@@ -9,7 +9,7 @@ import useIntersectionObsever from './useIntersectionObserver';
 
 interface CompanionRecruitmentListProps {
   data: { pages: AccompanyPostInfoList[] };
-  isInfinite: boolean;
+  isInfinite?: boolean;
   handleFetchNextPage: () => void;
   hasNextPage: boolean;
 }

--- a/app/search/_component/companion-recruitment-list.tsx
+++ b/app/search/_component/companion-recruitment-list.tsx
@@ -24,17 +24,19 @@ const CompanionRecruitmentList = ({
 
   return (
     <div className="flex w-full flex-col gap-6">
-      <span className="font-semibold">동행 모집</span>
-      <div className="grid w-full grid-cols-3 sm:grid-cols-1 mainmd:grid-cols-2 ">
+      <span className="p-4 font-semibold">동행 모집</span>
+      <div className="grid w-full grid-cols-3 gap-4 sm:grid-cols-1 mainmd:grid-cols-2 ">
         {data.pages?.map(page =>
           page?.accompanyPostInfos.map(({ id, status, gender, ...rest }) => (
-            <CompanionRecruitmentCard
-              key={id}
-              id={id}
-              status={status as CompanionRecruitStatus}
-              gender={gender as CompanionRecruitGender}
-              {...rest}
-            />
+            <div key={id} className="flex justify-center pt-4">
+              <CompanionRecruitmentCard
+                key={id}
+                id={id}
+                status={status as CompanionRecruitStatus}
+                gender={gender as CompanionRecruitGender}
+                {...rest}
+              />
+            </div>
           )),
         )}
         {isInfinite && <div ref={ref} />}

--- a/hooks/infinite/useInfiniteAccompanies.ts
+++ b/hooks/infinite/useInfiniteAccompanies.ts
@@ -3,10 +3,11 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getCompanionsList } from '~/apis/companion';
 
 const SIZE = 6;
-const useInfiniteAccompanies = (params: string) => {
+const useInfiniteAccompanies = (params: string, size?: number) => {
   return useInfiniteQuery({
     queryKey: ['accompanies', params],
-    queryFn: ({ pageParam }) => getCompanionsList(params, SIZE, pageParam),
+    queryFn: ({ pageParam }) =>
+      getCompanionsList(params, size !== undefined ? size : SIZE, pageParam),
     initialPageParam: 0,
     getNextPageParam: lastPage => {
       const { accompanyPostInfos } = lastPage;

--- a/hooks/queries/useFetchCarouselPerformances.ts
+++ b/hooks/queries/useFetchCarouselPerformances.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCarouselPerformances } from '~/apis/performance';
+
+export const useFetchCarouselPerformances = () => {
+  const { error, ...rest } = useQuery({
+    queryKey: ['carousel-performances'],
+    queryFn: getCarouselPerformances,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return { ...rest };
+};

--- a/mocks/handlers/index.ts
+++ b/mocks/handlers/index.ts
@@ -1,4 +1,3 @@
-import accompany from './accompany';
 import accompanyDetail from './accompanyDetail';
 import accompanyPerformances from './accompanyPerformances';
 import comment from './comment';
@@ -8,8 +7,6 @@ import reviews from './review';
 
 export const handlers = [
   ...members,
-  ...accompany,
-  // ...performances,
   ...message,
   ...comment,
   ...accompanyDetail,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -124,7 +124,7 @@ module.exports = {
         'page-min': '360px',
       },
       aspectRatio: {
-        carousel: '3/1',
+        carousel: '1/1',
       },
     },
   },


### PR DESCRIPTION
## 📝 작업 내용

1. 메인페이지 좌측에 필터에 sticky 속성을 추가하여 스크롤시에 자연스럽게 상단에 고정되도록 하였습니다.
2. 연경님이 구현하신 useInfiniteAccompany훅을 활용하여 메인페이지에 동행구인 글이 무한스크롤 되도록 하였습니다.
3. useInfiniteAccompany훅에 size를 기본 6으로 설정해두셨는데, oprtion으로 size를 받아 원하는 개수만큼 받아오도록 수정해야 해서 useInfiniteAccompany훅에 params 변경사항이 있습니다.
4. 메인페이지 무한스크롤은 더보기 버튼 없이 되도록 적용하였습니다.
5. 캐러샐 컴포넌트가 기존 가로3 세로1 비율이었으나, 포스터 크기를 고려하여 1:1로 수정하였습니다.
6. 캐러샐 데이터는 전체 공연에서 최신순으로 6개를 설정하였습니다. 이미지가 깨지는 포스터들이 있습니다.
7. 캐러샐 컴포넌트에 로딩 스켈레톤을 적용했습니다.

- close #151 

## 📷 스크린샷 (선택)
![image](https://github.com/GoGo-Ring/dongoorami-frontend/assets/91151775/ec08588a-c034-4d0c-ab16-9d614b8937d4)

