### PR TITLE
Fix: [#179] 캐러샐 내 CarouselNext버튼에 sm:hidden속성 추가로 버그 수정

### DIFF
--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -210,7 +210,7 @@ const CarouselPrevious = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        'absolute  h-8 w-8 rounded-full',
+        'absolute h-8  w-8 rounded-full sm:hidden',
         orientation === 'horizontal'
           ? '-left-12 top-1/2 -translate-y-1/2'
           : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
@@ -240,7 +240,7 @@ const CarouselNext = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        'absolute h-8 w-8 rounded-full',
+        'absolute h-8 w-8 rounded-full sm:hidden',
         orientation === 'horizontal'
           ? '-right-12 top-1/2 -translate-y-1/2'
           : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',


### PR DESCRIPTION
## 📝 작업 내용

PC기준으로는 모든 기능이 잘 동작하나, mobie view에서만
main페이지와 performaces페이지의 레이아웃은 동일하나 main 페이지에서만 header가 fixed되지 않는 오류를 발견하였습니다.
심지어 PC화면에서 width를 직접 줄인 경우에는 정상적이나 브라우저에서 지원하는 mobileview로 설정된 경우에 오류가 발생했습니다.

RootLayout에 위치한 header는 css fixed속성을 지니고 있는 상황입니다.
컴포넌트들을 소거하며 확인해보니 Shadcn에서 받아온 Carousel 중 이전, 다음 캐러샐로 이동하는 기능을 지닌 버튼인 CarouselPrev와 CarouselNext버튼이 없는 경우에는 정상적으로 header에 fixed속성이 적용되었습니다.

따라서 CarouselPrev CarouselNext에 있는 버튼에 sm:hidden 속성을 적용하여 해결하였습니다.

- close #179 


## 💬 리뷰 요구사항(선택)
버그가 고쳐졌지만 어떠한 이유로 해당 버그가 발생했던 것인지는 원인을 파악하지 못했습니다.
버튼에 적용된 absolute 속성이 header에 있는 fixed에 영향을 준 것 으로 파악이 되는데 
왜, 어떻게 영향을 주어 section내의 absolute속성이 header에 위치한 fixed에 영향을 주는지 모르겠습니다.

코드 및 ui 구조를 살펴보시고 알게되신다면 리뷰에 남겨주시면 감사하겠습니다.

