### PR TITLE
Fix: [#214] refresh token 만료시 에러처리 및 비로그인시 동행 글 작성 리다이렉트 처리 

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 
 import { PropsWithRequiredChildren } from '~/types/utils';
 
-const routes = ['/message', '/users', '/register'];
+const routes = ['/message', '/users', '/register', '/recruitment/new'];
 
 const AuthProvider = ({ children }: PropsWithRequiredChildren) => {
   const pathname = usePathname();


### PR DESCRIPTION
<!-- pr 제목은 아래와 같이 작성해주세요. -->
<!-- Commit Type: [#이슈 번호] 이슈 제목과 동일한 제목 -->

## 📝 작업 내용
- refresh token 만료시 에러처리를 진행하였습니다. 500 에러로 내려오고, message 가 내려오게됩니다.
- auth.tsx 의 routes 에 /recuitment/new 페이지를 추가하였습니다.

이제 token 만료에러와 미인증 사용자가 recruitment/new 접근시 login 페이지로 리다이렉트됩니다.

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- close #214 

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
